### PR TITLE
Apply hover animation settings for UI elements

### DIFF
--- a/src/components/common/Button/Button.module.scss
+++ b/src/components/common/Button/Button.module.scss
@@ -11,10 +11,11 @@
   font-weight: 600;
   padding: 10px 30px;
 
+  @extend %hover-animation;
+
   &:not(.noHover):hover {
-    color: #ffffff !important;
-    background-color: $primary;
-    text-decoration: none;
+    @extend .hover-background;
+    @extend .hover-text;
   }
 }
 
@@ -34,8 +35,10 @@
   font-size: 13px;
   line-height: 22px;
 
+  @extend %hover-animation;
+
   &:not(.noHover):hover {
-    background-color: #2a2a2a;
-    color: #ffffff;
+    @extend .hover-background;
+    @extend .hover-text;
   }
 }

--- a/src/components/features/NewFurniture/NewFurniture.module.scss
+++ b/src/components/features/NewFurniture/NewFurniture.module.scss
@@ -49,8 +49,12 @@
             font-size: 18px;
             display: block;
 
-            &.active,
+            &.active {
+              color: $primary;
+            }
             &:hover {
+              @extend %hover-animation;
+              @extend .hover-text-dark-bg;
               &::before {
                 content: "";
                 position: absolute;

--- a/src/components/layout/CompanyClaim/CompanyClaim.module.scss
+++ b/src/components/layout/CompanyClaim/CompanyClaim.module.scss
@@ -64,7 +64,8 @@
 
       &:hover {
         .cartIcon {
-          background-color: lighten($primary, 10%);
+          @extend %hover-animation;
+          background-color: lighten($hover-background-color, 10%);
         }
       }
     }

--- a/src/components/layout/Footer/Footer.module.scss
+++ b/src/components/layout/Footer/Footer.module.scss
@@ -23,7 +23,8 @@
             color: rgb(169, 169, 169);
 
             &:hover {
-              color: #ffffff;
+              @extend %hover-animation;
+              @extend .hover-text-dark-bg;
             }
           }
         }
@@ -72,7 +73,8 @@
             text-decoration: none;
 
             &:hover {
-              color: $primary;
+              @extend %hover-animation;
+              @extend .hover-text-dark-bg;
             }
           }
         }

--- a/src/components/layout/MenuBar/MenuBar.module.scss
+++ b/src/components/layout/MenuBar/MenuBar.module.scss
@@ -36,7 +36,11 @@
       font-weight: 500;
       letter-spacing: 1px;
 
-      &:hover,
+      &:hover{
+        @extend %hover-animation;
+        @extend .hover-text;
+        @extend .hover-background;
+      }
       &.active {
         background-color: $primary;
         color: #ffffff;

--- a/src/components/layout/TopBar/TopBar.module.scss
+++ b/src/components/layout/TopBar/TopBar.module.scss
@@ -17,7 +17,8 @@
         font-size: 13px;
 
         &:hover {
-          color: $primary;
+          @extend %hover-animation;
+          @extend .hover-text-dark-bg;
           text-decoration: none;
         }
       }

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -11,3 +11,38 @@ $primary: #d58e32;
 $text-color: #2a2a2a;
 
 $form-border-color: #292929;
+
+// ANIMATIONS
+
+// Animation time for different effects
+$hover-animation-time: 250ms;
+$hover-background-time: 250ms;
+$hover-text-time: 250ms;
+
+$hover-text-color: #ffffff;
+$hover-text-color-dark-bg: $primary;
+$hover-background-color: $primary;
+
+// Placeholder
+%hover-animation {
+  transition: $hover-animation-time;
+
+  &.hover-background {
+    transition: background-color $hover-background-time;
+    background-color: $hover-background-color;
+  }
+
+  &.hover-text {
+    transition: color $hover-text-time;
+    color: $hover-text-color;
+  }
+
+  &.hover-text-dark-bg {
+    transition: color $hover-text-time;
+    color: $hover-text-color-dark-bg;
+  }
+
+  &.hover-move {
+    transition: transform $hover-animation-time ease-in-out;
+  }
+}


### PR DESCRIPTION
Dodałem sekcję z animacjami w ustawieniach, w której utworzyłem placeholdery dla efektów hover. Zastąpiłem sztywno zapisane style nowo utworzonymi szablonami dla hoverów w całym kodzie. Zauważyłem problem z TopBar, gdzie wszystkie linki mają domyślnie biały kolor, przez co hover jest niewidoczny. Choć klient chciał mieć spójne efekty hover na całej stronie, uznałem, że w takim przypadku albo hover nic by nie zmieniał, jak w przypadku TopBar, albo tekst na białym tle stałby się całkowicie niewidoczny, jak w NewFurniture. W związku z tym stworzyłem dodatkowy placeholder .hover-text-dark-bg, dzięki czemu teraz mamy dwa typy efektów hover w zależności od tła.