### PR TITLE
Improved RWD for the footer

### DIFF
--- a/src/components/layout/Footer/Footer.js
+++ b/src/components/layout/Footer/Footer.js
@@ -17,7 +17,7 @@ const Footer = ({ children }) => (
     <div className={styles.footerMenu}>
       <div className='container'>
         <div className='row'>
-          <div className='col'>
+          <div className='col-lg-3 col-md-6 col-6'>
             <div className={styles.menuWrapper}>
               <h6>Information</h6>
               <ul>
@@ -36,7 +36,7 @@ const Footer = ({ children }) => (
               </ul>
             </div>
           </div>
-          <div className='col'>
+          <div className='col-lg-3 col-md-6 col-6'>
             <div className={styles.menuWrapper}>
               <h6>My account</h6>
               <ul>
@@ -55,7 +55,7 @@ const Footer = ({ children }) => (
               </ul>
             </div>
           </div>
-          <div className='col'>
+          <div className='col-lg-3 col-md-6 col-6'>
             <div className={styles.menuWrapper}>
               <h6>Information</h6>
               <ul>
@@ -73,8 +73,11 @@ const Footer = ({ children }) => (
                 </li>
               </ul>
             </div>
+            <div className='d-md-block d-lg-none order-md-1 mt-5'>
+              <img src='./images/cards.png' alt='Supported credit cards' />
+            </div>
           </div>
-          <div className='col'>
+          <div className='col-lg-3 col-md-6 col-6'>
             <div className={styles.menuWrapper}>
               <h6>Orders</h6>
               <ul>
@@ -92,7 +95,9 @@ const Footer = ({ children }) => (
                 </li>
               </ul>
             </div>
-            <img src='./images/cards.png' alt='Supported credit cards' />
+            <div className='d-none d-md-none d-lg-block'>
+              <img src='./images/cards.png' alt='Supported credit cards' />
+            </div>
           </div>
         </div>
       </div>
@@ -100,11 +105,11 @@ const Footer = ({ children }) => (
     <div className={styles.bottomBar}>
       <div className='container'>
         <div className='row align-items-center'>
-          <div className='col'></div>
-          <div className={'col text-center ' + styles.copyright}>
+          <div className='col-12 col-md-4 '></div>
+          <div className={'col-6 col-md-4 text-center ' + styles.copyright}>
             <p>©Copyright 2016 Bazar | All Rights Reserved</p>
           </div>
-          <div className={'col text-right ' + styles.socialMedia}>
+          <div className={'col-6 col-md-4 text-right fs-3 ' + styles.socialMedia}>
             <ul>
               <li>
                 <a href='#'>
@@ -121,6 +126,7 @@ const Footer = ({ children }) => (
                   <FontAwesomeIcon icon={faYoutube}>YouTube</FontAwesomeIcon>
                 </a>
               </li>
+              <br className='d-md-none'></br>
               <li>
                 <a href='#'>
                   <FontAwesomeIcon icon={faGooglePlusG}>Google Plus</FontAwesomeIcon>

--- a/src/components/layout/Footer/Footer.module.scss
+++ b/src/components/layout/Footer/Footer.module.scss
@@ -49,6 +49,9 @@
 
     :global(.container) > :global(.row) {
       height: 95px;
+      @media (max-width: 768px){
+        height: 150px;
+      }
     }
 
     .copyright {
@@ -62,17 +65,26 @@
 
     .socialMedia {
       ul {
-        margin: 0;
+        margin: 0 -40px 0 0;
         padding: 0;
         list-style: none;
+        @media (max-width:768px){
+          padding-right: 1.5rem;
+        }
 
         li {
           display: inline-block;
           margin-left: 1rem;
+          @media (max-width:768px){
+            margin: 0.3rem 1.5rem 0.5rem 0;
+          }
 
           a {
             color: rgb(169, 169, 169);
             text-decoration: none;
+            @media(max-width: 768px){
+              font-size: 25px;
+            }
 
             &:hover {
               @extend %hover-animation;

--- a/src/components/layout/Footer/Footer.module.scss
+++ b/src/components/layout/Footer/Footer.module.scss
@@ -1,6 +1,8 @@
 @import "../../../styles/settings.scss";
 
 .root {
+  min-width: 320px;
+
   .footerMenu {
     background-color: $footer-bg;
     padding: 3rem 0;


### PR DESCRIPTION
Zmiany w stopce - RWD dla małych ekranów

- Poprawiłem RWD na małych ekranach poprzez ustawienie max-width dla całej stopki na 320px, dzięki czemu do tej szerokości wszystkie elementy wyświetlają się prawidłowo.

- Ikony mediów społecznościowych zostały podzielone na dwie części, aby lepiej mieściły się na najmniejszych ekranach.

- Udało się uniknąć zmniejszania górnej części stopki do jednej kolumny, zachowując odpowiednią strukturę na małych ekranach.

Link do zadania: https://projects.kodilla.com/browse/WDP250101-18