### PR TITLE
bugfix/update-compare-btn-gallery

### DIFF
--- a/src/components/common/PromotedBox/PromotedBox.js
+++ b/src/components/common/PromotedBox/PromotedBox.js
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import CompareBtn from '../../features/CompareBtn/CompareBtn';
-import { faShoppingBasket, faExchangeAlt } from '@fortawesome/free-solid-svg-icons';
+import { faShoppingBasket } from '@fortawesome/free-solid-svg-icons';
 import { faEye } from '@fortawesome/free-regular-svg-icons';
 import Button from '../Button/Button';
 import StarRating from '../../features/StarRating/StarRating';
@@ -118,11 +118,7 @@ const PromotedBox = ({ hotDeal, dotsCount, activeDot, onDotClick }) => {
             price={hotDeal.price}
             category={hotDeal.category}
           />
-          <CompareBtn
-            isCompared={hotDeal.isCompared}
-            id={hotDeal.id}
-            category={hotDeal.category}
-          />
+          <CompareBtn id={hotDeal.id} category={hotDeal.category} />
         </div>
         <div className={styles.prices}>
           {hotDeal.oldPrice && (

--- a/src/components/views/TabContentItem/TabContentItem.js
+++ b/src/components/views/TabContentItem/TabContentItem.js
@@ -76,11 +76,7 @@ const TabContentItem = ({ products }) => {
             price={activeImage.price}
             category={activeImage.category}
           />
-          <CompareBtn
-            isCompared={activeImage.isCompared}
-            id={activeImage.id}
-            category={activeImage.category}
-          />
+          <CompareBtn id={activeImage.id} category={activeImage.category} />
           <Button
             variant='outline'
             data-tooltip-id='Add to cart'


### PR DESCRIPTION
Po dodaniu elementu do porównywarki cały mechanizm dodawania do niej produktów był prawidłowy we wszystkich modułach, ale nie podświetlał się aktywny przycisk tylko i wyłącznie w skecji galeria - w pozostałych komponentach prawidłowo się podświetlały. 
Zaktualizowano komponent compareBtn wraz z komponentami w których on się znajduje - po poprawkach podświetlanie aktywnego przycisku działa prawidłowo we wszystkich sekcjach.