### PR TITLE
bugfix/update-compare-btn-gallery-2

### DIFF
--- a/src/components/features/CompareBarItem/CompareBarItem.js
+++ b/src/components/features/CompareBarItem/CompareBarItem.js
@@ -5,7 +5,6 @@ import styles from './CompareBarItem.module.scss';
 import Button from '../../common/Button/Button';
 import { useDispatch } from 'react-redux';
 import { removeFromCompare } from '../../../redux/compareReducer';
-import { setCompareStatus } from '../../../redux/productsRedux';
 
 const CompareBarItem = ({ id, category }) => {
   const dispatch = useDispatch();
@@ -13,11 +12,10 @@ const CompareBarItem = ({ id, category }) => {
   const remove = e => {
     e.preventDefault();
     dispatch(removeFromCompare(id));
-    dispatch(setCompareStatus({ id, isCompared: false }));
   };
 
   return (
-    <div className={clsx(styles.imageWrapper, 'py-2 col-3')}>
+    <div className={clsx(styles.imageWrapper, 'col-3 py-2')}>
       <img
         className='img-thumbnail'
         alt={`product-image-${id}`}

--- a/src/components/features/CompareBtn/CompareBtn.js
+++ b/src/components/features/CompareBtn/CompareBtn.js
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styles from './CompareBtn.module.scss';
 import { useSelector } from 'react-redux';
-import { setCompareStatus } from '../../../redux/productsRedux';
 import clsx from 'clsx';
 import {
   updateFullCompare,
@@ -18,10 +17,13 @@ import Button from '../../common/Button/Button';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons';
 
-const CompareBtn = ({ isCompared, id, category }) => {
+const CompareBtn = ({ id, category }) => {
   const dispatch = useDispatch();
   const productsSelected = useSelector(getComparedProducts);
   const fullCompared = useSelector(getComparedFullProducts);
+  const isCompared = productsSelected.find(
+    productSelected => productSelected.id === id
+  );
 
   useEffect(() => {
     if (productsSelected.length === 4) {
@@ -33,14 +35,12 @@ const CompareBtn = ({ isCompared, id, category }) => {
 
   const clickedToCompare = e => {
     e.preventDefault();
-    if (id && !productsSelected.find(product => product.id === id)) {
+    if (id && !isCompared) {
       if (productsSelected.length < 4) {
         dispatch(addToCompare({ id, category }));
-        dispatch(setCompareStatus({ id, isCompared: true }));
       }
     } else {
       dispatch(removeFromCompare(id));
-      dispatch(setCompareStatus({ id, isCompared: false }));
     }
   };
 
@@ -58,7 +58,6 @@ const CompareBtn = ({ isCompared, id, category }) => {
 };
 
 CompareBtn.propTypes = {
-  isCompared: PropTypes.bool,
   id: PropTypes.string,
   category: PropTypes.string,
 };

--- a/src/components/features/NewFurniture/NewFurniture.test.js
+++ b/src/components/features/NewFurniture/NewFurniture.test.js
@@ -1,63 +1,16 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+import store from '../../../redux/store';
 import NewFurniture from './NewFurniture';
 
 describe('Component NewFurniture', () => {
-  const categories = [{ id: 'bed', name: 'Beds' }];
-  const products = [
-    {
-      id: '1',
-      name: 'Bed 1',
-      category: 'bed',
-      oldPrice: 150,
-      price: 100,
-      stars: 4,
-      promo: 'sale',
-      newFurniture: true,
-    },
-    {
-      id: '2',
-      name: 'Bed 2',
-      category: 'bed',
-      oldPrice: 250,
-      price: 150,
-      stars: 5,
-      promo: 'sale',
-      newFurniture: true,
-    },
-    {
-      id: '3',
-      name: 'Bed 3',
-      category: 'bed',
-      oldPrice: 100,
-      price: 50,
-      stars: 3,
-      promo: 'sale',
-      newFurniture: true,
-    },
-    {
-      id: '4',
-      name: 'Bed 4',
-      category: 'bed',
-      oldPrice: 120,
-      price: 70,
-      stars: 3,
-      promo: 'sale',
-      newFurniture: true,
-    },
-    {
-      id: '5',
-      name: 'Bed 5',
-      category: 'bed',
-      oldPrice: 80,
-      price: 50,
-      stars: 3,
-      promo: 'sale',
-      newFurniture: true,
-    },
-  ];
   it('should render without crashing', () => {
-    const component = shallow(<NewFurniture />);
+    const component = shallow(
+      <Provider store={store}>
+        <NewFurniture />
+      </Provider>
+    );
     expect(component).toBeTruthy();
   });
 });

--- a/src/redux/productsRedux.js
+++ b/src/redux/productsRedux.js
@@ -1,5 +1,6 @@
 /* selectors */
 export const getAll = ({ products }) => products;
+
 export const getCount = ({ products }) => products.length;
 
 export const getNew = ({ products }) =>
@@ -25,20 +26,9 @@ export const getBySale = ({ products }) =>
 export const getByRated = ({ products }) =>
   products.filter(product => product.stars > 2);
 
-// actions
-const createActionName = actionName => `app/products/${actionName}`;
-const SET_COMPARE_STATUS = createActionName('SET_COMPARE_STATUS');
-
-// action creators
-export const setCompareStatus = payload => ({ type: SET_COMPARE_STATUS, payload });
-
 /* reducer */
 export default function reducer(statePart = [], action = {}) {
   switch (action.type) {
-    case SET_COMPARE_STATUS:
-      return statePart.map(product =>
-        product.id === action.payload.id ? { ...product, ...action.payload } : product
-      );
     default:
       return statePart;
   }


### PR DESCRIPTION
Z brancha bugfix/update-compare-btn-gallery nie zostały pobrane niezbędne zmiany w komponentach CompareBtn, CompareBarItem oraz productRedux. 

W tym branchu przesyłam uzupełnienie do brakujących zmian w powyższych komponentach dla prawidłowego podświetlania aktywnych przycisków porównywarki.